### PR TITLE
Fixes bugs in findStopLessThanOrEqualTo algorithm

### DIFF
--- a/src/style-spec/expression/stops.js
+++ b/src/style-spec/expression/stops.js
@@ -11,19 +11,22 @@ export type Stops = Array<[number, Expression]>;
  * @private
  */
 export function findStopLessThanOrEqualTo(stops: Array<number>, input: number) {
-    const n = stops.length;
+    const n = stops.length - 1;
     let lowerIndex = 0;
-    let upperIndex = n - 1;
+    let upperIndex = n;
     let currentIndex = 0;
-    let currentValue, upperValue;
+    let currentValue, nextValue;
 
     while (lowerIndex <= upperIndex) {
         currentIndex = Math.floor((lowerIndex + upperIndex) / 2);
         currentValue = stops[currentIndex];
-        upperValue = stops[currentIndex + 1];
-        if (input === currentValue || input > currentValue && input < upperValue) { // Search complete
+        nextValue = stops[currentIndex + 1];
+
+        if (currentValue <= input && (currentIndex === n || input < nextValue)) { // Search complete
             return currentIndex;
-        } else if (currentValue < input) {
+        }
+
+        if (currentValue <= input) {
             lowerIndex = currentIndex + 1;
         } else if (currentValue > input) {
             upperIndex = currentIndex - 1;
@@ -32,5 +35,5 @@ export function findStopLessThanOrEqualTo(stops: Array<number>, input: number) {
         }
     }
 
-    return Math.max(currentIndex - 1, 0);
+    return 0;
 }


### PR DESCRIPTION
## Old behaviour
- When the input > all stops it returned the second-last stop, should have been the last stop.
```
findStopLessThanOrEqualTo([0, 1, 2, 3, 4, 5, 6, 7], 8) // 6 but should have been 7
```

- When more than one stop had the same value it didn't always return the last stop
```
findStopLessThanOrEqualTo([0.5, 0.5], 0.5) // 0 but should have been 1
```
## New behaviour
- When the input > all stops it returns the last stop.
```
findStopLessThanOrEqualTo([0, 1, 2, 3, 4, 5, 6, 7], 8) // 7
```

- When more than one stop has the same value it always returns the last stop
```
findStopLessThanOrEqualTo([0.5, 0.5], 0.5) // 1
```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

<!-- If your PR affects documentation relevant to the currently released version, please use `publisher-production` as the base branch. See https://github.com/mapbox/mapbox-gl-js/blob/master/docs/README.md#committing-and-publishing-documentation -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] document any changes to public APIs
 - [ ] post benchmark scores
 - [ ] manually test the debug page
 - [ ] tagged `@mapbox/studio` and/or `@mapbox/maps-design` if this PR includes style spec changes
 - [ ] tagged `@mapbox/gl-native` if this PR includes shader changes or needs a native port